### PR TITLE
ci: add Gravity

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,3 +58,18 @@ jobs:
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps
       - run: GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} && pnpm run pw
+      - run: pnpm run test
+
+  Gravity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8.6.3
+          run_install: true
+      - run: pnpm install
+      - run: pnpm build
+      - run: pnpx @gravityci/cli 'dist/**/*'
+        env:
+          GRAVITY_TOKEN: ${{ secrets.GRAVITY_TOKEN }}


### PR DESCRIPTION
Hi! I'm @oscard0m, and I work at [Mainmatter](https://mainmatter.com).

We really appreciate the great work you're doing at `melt-ui/melt-ui`! We thought [Gravity](https://gravity.ci) could be useful to the project.

## What is Gravity?

Gravity is a free tool that helps maintainers stay on top of asset size increases as part of their CI pipeline. Gravity catches potentially unintended or disproportionate growth of _bundle_ sizes that result out of code changes in a PR before they hit
  production, e.g. added dependencies that grow the _bundle_ size disproportionally. Without Gravity, it's hard for maintainers to even be aware of these changes and _bundle_ sizes often just keep growing unnoticed.

Here's a quick video showing Gravity in action:

https://youtu.be/2vD_geF_Ask

You can read a more detailed explanation in our
[blog post](https://gravity.ci/blog/2025/03/19/gravity/).

We also prepared an example PR with Gravity set up on a fork of `melt-ui/melt-ui`: 
- https://github.com/mainmatter/melt-ui/pull/1
- https://github.com/mainmatter/melt-ui/pull/4

## Last steps

This PR introduces Gravity to the project, but it is expected the maintainers
take some extra actions to connect all the dots:

1. Install [Gravity GitHub App](https://github.com/apps/gravity-ci) to your organization.
2. Once installed, create a new Gravity project in [https://gravity.ci](https://gravity.ci).
3. [Set up the Gravity token for your repo](https://github.com/melt-ui/melt-ui/settings/secrets/actions) and add the Gravity job to your GitHub Actions workflow.